### PR TITLE
feat: 实现延迟测试功能

### DIFF
--- a/src/core/hotkey/schema.ts
+++ b/src/core/hotkey/schema.ts
@@ -53,6 +53,7 @@ export const hotkeyCommandList = [
   'playPauseAudio',
   'seekForward',
   'volumeDown',
+  'delayTestTap',
 
   'copy',
   'cut',
@@ -96,6 +97,7 @@ export const getDefaultHotkeyMap = () =>
     seekForward: k('ArrowRight'),
     volumeUp: k('ArrowUp'),
     volumeDown: k('ArrowDown'),
+    delayTestTap: k('Space'),
     undo: k(Ctrl, 'z'),
     redo: [k(Ctrl, 'y'), k(Ctrl, Shift, 'z')],
     find: k(Ctrl, 'f'),

--- a/src/core/hotkey/schema.ts
+++ b/src/core/hotkey/schema.ts
@@ -97,7 +97,7 @@ export const getDefaultHotkeyMap = () =>
     seekForward: k('ArrowRight'),
     volumeUp: k('ArrowUp'),
     volumeDown: k('ArrowDown'),
-    delayTestTap: k('Space'),
+    delayTestTap: k('g'),
     undo: k(Ctrl, 'z'),
     redo: [k(Ctrl, 'y'), k(Ctrl, Shift, 'z')],
     find: k(Ctrl, 'f'),

--- a/src/core/pref/persistence.ts
+++ b/src/core/pref/persistence.ts
@@ -28,9 +28,10 @@ export function loadPreference(): PreferenceSchema {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return getDefaultPref()
     const parsed = JSON.parse(raw) as PersistedPref
-    if (parsed.prefVersion > PREF_VERSION)
+    const prefVersion = parsed.prefVersion ?? 0
+    if (prefVersion > PREF_VERSION)
       console.warn(
-        `Found preference version ${parsed.prefVersion}, newer than current version ${PREF_VERSION}.`,
+        `Found preference version ${prefVersion}, newer than current version ${PREF_VERSION}.`,
       )
     if (parsed.data.hotkeyMap) {
       const defaultHotkeyMap = getDefaultHotkeyMap()
@@ -39,6 +40,7 @@ export function loadPreference(): PreferenceSchema {
         ...omit(parsed.data.hotkeyMap, reservedHotkeyCommands),
       }
       if (
+        prefVersion < PREF_VERSION &&
         parsed.data.hotkeyMap.delayTestTap?.length === 1 &&
         isHotkeyMatch(parsed.data.hotkeyMap.delayTestTap[0], LEGACY_DELAY_TEST_TAP)
       ) {

--- a/src/core/pref/persistence.ts
+++ b/src/core/pref/persistence.ts
@@ -38,7 +38,10 @@ export function loadPreference(): PreferenceSchema {
         ...defaultHotkeyMap,
         ...omit(parsed.data.hotkeyMap, reservedHotkeyCommands),
       }
-      if (parsed.data.hotkeyMap.delayTestTap?.some((binding) => isHotkeyMatch(binding, LEGACY_DELAY_TEST_TAP))) {
+      if (
+        parsed.data.hotkeyMap.delayTestTap?.length === 1 &&
+        isHotkeyMatch(parsed.data.hotkeyMap.delayTestTap[0], LEGACY_DELAY_TEST_TAP)
+      ) {
         hotkeyMap.delayTestTap = defaultHotkeyMap.delayTestTap
       }
       parsed.data.hotkeyMap = hotkeyMap

--- a/src/core/pref/persistence.ts
+++ b/src/core/pref/persistence.ts
@@ -1,13 +1,21 @@
 import stableStringify from 'json-stable-stringify'
 import { omit } from 'lodash-es'
 
-import { getDefaultHotkeyMap } from '@core/hotkey'
+import { getDefaultHotkeyMap, isHotkeyMatch } from '@core/hotkey'
 import { reservedHotkeyCommands } from '@core/hotkey/schema'
+import type { HotKey } from '@core/hotkey/types'
 
 import { type PreferenceSchema, getDefaultPref } from './schema'
 
 const STORAGE_KEY = 'amll_editor:preference'
-const PREF_VERSION = 1
+const PREF_VERSION = 2
+
+const LEGACY_DELAY_TEST_TAP: HotKey.Key = {
+  code: 'Space',
+  ctrl: false,
+  alt: false,
+  shift: false,
+}
 
 interface PersistedPref {
   appVersion: string
@@ -24,11 +32,17 @@ export function loadPreference(): PreferenceSchema {
       console.warn(
         `Found preference version ${parsed.prefVersion}, newer than current version ${PREF_VERSION}.`,
       )
-    if (parsed.data.hotkeyMap)
-      parsed.data.hotkeyMap = {
-        ...getDefaultHotkeyMap(),
+    if (parsed.data.hotkeyMap) {
+      const defaultHotkeyMap = getDefaultHotkeyMap()
+      const hotkeyMap = {
+        ...defaultHotkeyMap,
         ...omit(parsed.data.hotkeyMap, reservedHotkeyCommands),
       }
+      if (parsed.data.hotkeyMap.delayTestTap?.some((binding) => isHotkeyMatch(binding, LEGACY_DELAY_TEST_TAP))) {
+        hotkeyMap.delayTestTap = defaultHotkeyMap.delayTestTap
+      }
+      parsed.data.hotkeyMap = hotkeyMap
+    }
     return {
       ...getDefaultPref(),
       ...parsed.data,

--- a/src/core/pref/schema.ts
+++ b/src/core/pref/schema.ts
@@ -15,6 +15,7 @@ export interface PreferenceSchema {
   macStyleShortcuts: boolean
   hotkeyMap: HotKey.Map
   audioSeekingStepMs: number
+  latencyTestBpm: number
   // Timing
   globalLatencyMs: number
   alwaysIgnoreBackground: boolean
@@ -43,6 +44,7 @@ export const getDefaultPref = (): PreferenceSchema => ({
   macStyleShortcuts: isAppleDevice(),
   hotkeyMap: getDefaultHotkeyMap(),
   audioSeekingStepMs: 5000,
+  latencyTestBpm: 120,
   globalLatencyMs: 0,
   alwaysIgnoreBackground: false,
   hideLineTiming: true,

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -160,6 +160,7 @@ const en = {
     timeShift: {
       groupLabel: 'Time Shift',
       delayTest: 'Delay Test',
+      delayTestDesc: 'Open the latency test dialog to measure tap timing against the beep track.',
       delay: 'Delay',
       batchTimeShift: 'Batch Shift',
       batchTimeShiftDesc:
@@ -613,6 +614,7 @@ const en = {
       playPauseAudio: 'Play / Pause',
       seekForward: 'Seek Forward',
       volumeDown: 'Volume Down',
+      delayTestTap: 'Delay Test Tap',
     },
     keyNames: {
       space: 'Space',
@@ -740,6 +742,21 @@ const en = {
     applyToSyl: 'Apply to Selected Syllables',
     applyToLine: 'Apply to Selected Lines',
     applyToAll: 'Apply to All',
+  },
+  delayTestDialog: {
+    header: 'Delay Test',
+    description: 'Press the configured key on every beep to measure input latency.',
+    tapHint: 'Press',
+    bpmLabel: 'BPM',
+    signHint: 'Positive = early, negative = late',
+    current: 'Current',
+    fastest: 'Fastest',
+    slowest: 'Slowest',
+    noSamples: 'No taps yet',
+    start: 'Start',
+    stop: 'Stop',
+    applyCurrent: 'Apply Current',
+    applyAverage: 'Apply Average',
   },
   consoleArt,
 } as const satisfies Translations

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -288,6 +288,8 @@ const en = {
         macStyleShortcutsDesc: 'Display shortcuts using ⌘, ⌥ symbols etc.',
         audioSeekingStepMs: 'Seek step size',
         audioSeekingStepMsDesc: 'Time to jump when using hotkeys (ms)',
+        latencyTestBpm: 'Delay test BPM',
+        latencyTestBpmDesc: 'Beep rate used by the latency test dialog',
         swapTranslateRoman: 'Swap translation & romanization panels',
         swapTranslateRomanDesc: 'Place romanization panel on the left',
         hideTranslateRoman: 'Hide translation & romanization panels',

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -832,14 +832,22 @@ type RootTranslation = {
 				 * 音​频​按​键​跳​转​步​长
 				 */
 				audioSeekingStepMs: string
-				/**
-				 * 按​键​快​进​或​快​退​时​跳​转​的​时​长​ ​(​毫​秒​)
-				 */
-				audioSeekingStepMsDesc: string
-				/**
-				 * 交​换​翻​译​与​音​译​框​位​置
-				 */
-				swapTranslateRoman: string
+			/**
+			 * 按​键​快​进​或​快​退​时​跳​转​的​时​长​ ​(​毫​秒​)
+			 */
+			audioSeekingStepMsDesc: string
+			/**
+			 * 延​迟​测​试​ ​B​P​M
+			 */
+			latencyTestBpm: string
+			/**
+			 * 延​迟​测​试​对​话​框​使​用​的​蜂​鸣​节​拍
+			 */
+			latencyTestBpmDesc: string
+			/**
+			 * 交​换​翻​译​与​音​译​框​位​置
+			 */
+			swapTranslateRoman: string
 				/**
 				 * 在​内​容​视​图​将​音​译​框​置​于​左​侧​，​并​影​响​查​找​顺​序
 				 */
@@ -3000,14 +3008,22 @@ export type TranslationFunctions = {
 				 * 音频按键跳转步长
 				 */
 				audioSeekingStepMs: () => LocalizedString
-				/**
-				 * 按键快进或快退时跳转的时长 (毫秒)
-				 */
-				audioSeekingStepMsDesc: () => LocalizedString
-				/**
-				 * 交换翻译与音译框位置
-				 */
-				swapTranslateRoman: () => LocalizedString
+			/**
+			 * 按键快进或快退时跳转的时长 (毫秒)
+			 */
+			audioSeekingStepMsDesc: () => LocalizedString
+			/**
+			 * 延迟测试 BPM
+			 */
+			latencyTestBpm: () => LocalizedString
+			/**
+			 * 延迟测试对话框使用的蜂鸣节拍
+			 */
+			latencyTestBpmDesc: () => LocalizedString
+			/**
+			 * 交换翻译与音译框位置
+			 */
+			swapTranslateRoman: () => LocalizedString
 				/**
 				 * 在内容视图将音译框置于左侧，并影响查找顺序
 				 */

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -832,22 +832,22 @@ type RootTranslation = {
 				 * 音​频​按​键​跳​转​步​长
 				 */
 				audioSeekingStepMs: string
-			/**
-			 * 按​键​快​进​或​快​退​时​跳​转​的​时​长​ ​(​毫​秒​)
-			 */
-			audioSeekingStepMsDesc: string
-			/**
-			 * 延​迟​测​试​ ​B​P​M
-			 */
-			latencyTestBpm: string
-			/**
-			 * 延​迟​测​试​对​话​框​使​用​的​蜂​鸣​节​拍
-			 */
-			latencyTestBpmDesc: string
-			/**
-			 * 交​换​翻​译​与​音​译​框​位​置
-			 */
-			swapTranslateRoman: string
+				/**
+				 * 按​键​快​进​或​快​退​时​跳​转​的​时​长​ ​(​毫​秒​)
+				 */
+				audioSeekingStepMsDesc: string
+				/**
+				 * 延​迟​测​试​ ​B​P​M
+				 */
+				latencyTestBpm: string
+				/**
+				 * 延​迟​测​试​对​话​框​使​用​的​蜂​鸣​节​拍
+				 */
+				latencyTestBpmDesc: string
+				/**
+				 * 交​换​翻​译​与​音​译​框​位​置
+				 */
+				swapTranslateRoman: string
 				/**
 				 * 在​内​容​视​图​将​音​译​框​置​于​左​侧​，​并​影​响​查​找​顺​序
 				 */
@@ -3008,22 +3008,22 @@ export type TranslationFunctions = {
 				 * 音频按键跳转步长
 				 */
 				audioSeekingStepMs: () => LocalizedString
-			/**
-			 * 按键快进或快退时跳转的时长 (毫秒)
-			 */
-			audioSeekingStepMsDesc: () => LocalizedString
-			/**
-			 * 延迟测试 BPM
-			 */
-			latencyTestBpm: () => LocalizedString
-			/**
-			 * 延迟测试对话框使用的蜂鸣节拍
-			 */
-			latencyTestBpmDesc: () => LocalizedString
-			/**
-			 * 交换翻译与音译框位置
-			 */
-			swapTranslateRoman: () => LocalizedString
+				/**
+				 * 按键快进或快退时跳转的时长 (毫秒)
+				 */
+				audioSeekingStepMsDesc: () => LocalizedString
+				/**
+				 * 延迟测试 BPM
+				 */
+				latencyTestBpm: () => LocalizedString
+				/**
+				 * 延迟测试对话框使用的蜂鸣节拍
+				 */
+				latencyTestBpmDesc: () => LocalizedString
+				/**
+				 * 交换翻译与音译框位置
+				 */
+				swapTranslateRoman: () => LocalizedString
 				/**
 				 * 在内容视图将音译框置于左侧，并影响查找顺序
 				 */
@@ -4286,18 +4286,57 @@ export type TranslationFunctions = {
 		applyToAll: () => LocalizedString
 	}
 	delayTestDialog: {
+		/**
+		 * 延迟测试
+		 */
 		header: () => LocalizedString
+		/**
+		 * 在每次蜂鸣时按下配置的按键，以测量输入延迟。
+		 */
 		description: () => LocalizedString
+		/**
+		 * 按下
+		 */
 		tapHint: () => LocalizedString
+		/**
+		 * BPM
+		 */
 		bpmLabel: () => LocalizedString
+		/**
+		 * 正值表示更快，负值表示更慢
+		 */
 		signHint: () => LocalizedString
+		/**
+		 * 当前
+		 */
 		current: () => LocalizedString
+		/**
+		 * 最快
+		 */
 		fastest: () => LocalizedString
+		/**
+		 * 最慢
+		 */
 		slowest: () => LocalizedString
+		/**
+		 * 尚无按键记录
+		 */
 		noSamples: () => LocalizedString
+		/**
+		 * 开始
+		 */
 		start: () => LocalizedString
+		/**
+		 * 结束
+		 */
 		stop: () => LocalizedString
+		/**
+		 * 应用当前值
+		 */
 		applyCurrent: () => LocalizedString
+		/**
+		 * 应用平均值
+		 */
 		applyAverage: () => LocalizedString
 	}
 	/**

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -424,6 +424,10 @@ type RootTranslation = {
 			 */
 			delayTest: string
 			/**
+			 * 打​开​延​迟​测​试​对​话​框​，​测​量​按​键​与​蜂​鸣​之​间​的​延​迟​。
+			 */
+			delayTestDesc: string
+			/**
 			 * 延​迟
 			 */
 			delay: string
@@ -1768,6 +1772,10 @@ type RootTranslation = {
 			 * 减​小​音​量
 			 */
 			volumeDown: string
+			/**
+			 * 延​迟​测​试​按​键
+			 */
+			delayTestTap: string
 		}
 		keyNames: {
 			/**
@@ -2097,6 +2105,60 @@ type RootTranslation = {
 		 * 应​用​到​全​文
 		 */
 		applyToAll: string
+	}
+	delayTestDialog: {
+		/**
+		 * 延​迟​测​试
+		 */
+		header: string
+		/**
+		 * 在​每​次​蜂​鸣​时​按​下​配​置​的​按​键​，​以​测​量​输​入​延​迟​。
+		 */
+		description: string
+		/**
+		 * 按​下
+		 */
+		tapHint: string
+		/**
+		 * B​P​M
+		 */
+		bpmLabel: string
+		/**
+		 * 正​值​表​示​更​快​，​负​值​表​示​更​慢
+		 */
+		signHint: string
+		/**
+		 * 当​前
+		 */
+		current: string
+		/**
+		 * 最​快
+		 */
+		fastest: string
+		/**
+		 * 最​慢
+		 */
+		slowest: string
+		/**
+		 * 尚​无​按​键​记​录
+		 */
+		noSamples: string
+		/**
+		 * 开​始
+		 */
+		start: string
+		/**
+		 * 结​束
+		 */
+		stop: string
+		/**
+		 * 应​用​当​前​值
+		 */
+		applyCurrent: string
+		/**
+		 * 应​用​平​均​值
+		 */
+		applyAverage: string
 	}
 	/**
 	 * ╭​─​─​─​─​─​─​─​─​─​─​╮​ ​ ​ ​ ​ ​ ​ ​╶​╴​ ​ ​ ​ ​┌​─​╴​ ​ ​╶​─​┐​┌​─​┐​ ​ ​ ​ ​┌​─​┐​ ​ ​ ​ ​ ​ ​┌​─​─​─​─​─​┐​ ​ ​ ​ ​┌​─​┐​┌​─​┐​
@@ -2529,6 +2591,10 @@ export type TranslationFunctions = {
 			 * 延迟测试
 			 */
 			delayTest: () => LocalizedString
+			/**
+			 * 打开延迟测试对话框，测量按键与蜂鸣之间的延迟。
+			 */
+			delayTestDesc: () => LocalizedString
 			/**
 			 * 延迟
 			 */
@@ -3870,6 +3936,10 @@ export type TranslationFunctions = {
 			 * 减小音量
 			 */
 			volumeDown: () => LocalizedString
+			/**
+			 * 延迟测试按键
+			 */
+			delayTestTap: () => LocalizedString
 		}
 		keyNames: {
 			/**
@@ -4198,6 +4268,21 @@ export type TranslationFunctions = {
 		 * 应用到全文
 		 */
 		applyToAll: () => LocalizedString
+	}
+	delayTestDialog: {
+		header: () => LocalizedString
+		description: () => LocalizedString
+		tapHint: () => LocalizedString
+		bpmLabel: () => LocalizedString
+		signHint: () => LocalizedString
+		current: () => LocalizedString
+		fastest: () => LocalizedString
+		slowest: () => LocalizedString
+		noSamples: () => LocalizedString
+		start: () => LocalizedString
+		stop: () => LocalizedString
+		applyCurrent: () => LocalizedString
+		applyAverage: () => LocalizedString
 	}
 	/**
 	 * ╭──────────╮       ╶╴    ┌─╴  ╶─┐┌─┐    ┌─┐      ┌─────┐    ┌─┐┌─┐

--- a/src/i18n/zh-hans/index.ts
+++ b/src/i18n/zh-hans/index.ts
@@ -279,6 +279,8 @@ const zhHans = {
         macStyleShortcutsDesc: '使用 ⌘、⌥ 等符号展示组合键',
         audioSeekingStepMs: '音频按键跳转步长',
         audioSeekingStepMsDesc: '按键快进或快退时跳转的时长 (毫秒)',
+        latencyTestBpm: '延迟测试 BPM',
+        latencyTestBpmDesc: '延迟测试对话框使用的蜂鸣节拍',
         swapTranslateRoman: '交换翻译与音译框位置',
         swapTranslateRomanDesc: '在内容视图将音译框置于左侧，并影响查找顺序',
         hideTranslateRoman: '隐藏翻译音译框',

--- a/src/i18n/zh-hans/index.ts
+++ b/src/i18n/zh-hans/index.ts
@@ -156,6 +156,7 @@ const zhHans = {
     timeShift: {
       groupLabel: '时移',
       delayTest: '延迟测试',
+      delayTestDesc: '打开延迟测试对话框，测量按键与蜂鸣之间的延迟。',
       delay: '延迟',
       batchTimeShift: '批量时移',
       batchTimeShiftDesc: '打开批量时移对话框，调整多个音节或行的时间戳。',
@@ -591,6 +592,7 @@ const zhHans = {
       playPauseAudio: '播放/暂停音频',
       seekForward: '快进',
       volumeDown: '减小音量',
+      delayTestTap: '延迟测试按键',
     },
     keyNames: {
       space: '空格',
@@ -716,6 +718,21 @@ const zhHans = {
     applyToSyl: '应用到选定音节',
     applyToLine: '应用到选定行',
     applyToAll: '应用到全文',
+  },
+  delayTestDialog: {
+    header: '延迟测试',
+    description: '在每次蜂鸣时按下配置的按键，以测量输入延迟。',
+    tapHint: '按下',
+    bpmLabel: 'BPM',
+    signHint: '正值表示更快，负值表示更慢',
+    current: '当前',
+    fastest: '最快',
+    slowest: '最慢',
+    noSamples: '尚无按键记录',
+    start: '开始',
+    stop: '结束',
+    applyCurrent: '应用当前值',
+    applyAverage: '应用平均值',
   },
   consoleArt,
 } satisfies BaseTranslation

--- a/src/ui/dialogs/dialogComponents/DelayTestDialog.vue
+++ b/src/ui/dialogs/dialogComponents/DelayTestDialog.vue
@@ -1,0 +1,501 @@
+<template>
+  <Dialog
+    v-model:visible="visible"
+    :header="tt.header()"
+    class="thin-padding delay-test-dialog"
+    disable-global-hotkeys
+  >
+    <div class="delay-test-content" v-focustrap>
+      <div class="delay-test-description">{{ tt.description() }}</div>
+      <div class="delay-test-hint">
+        <span>{{ tt.tapHint() }}</span>
+        <kbd class="delay-test-key">{{ tapKeyLabel }}</kbd>
+      </div>
+
+      <div class="delay-test-beats" aria-label="beat-visualizer">
+        <span
+          v-for="beat in 4"
+          :key="beat"
+          class="delay-test-beat"
+          :class="{ active: isRunning && currentBeatIndex === beat - 1 }"
+        />
+      </div>
+
+      <div class="delay-test-stats">
+        <div class="delay-test-stat">
+          <span class="delay-test-stat-label">{{ tt.current() }}</span>
+          <strong class="delay-test-value" :class="offsetTone(currentOffsetMs)">{{
+            formatOffset(currentOffsetMs)
+          }}</strong>
+        </div>
+        <div class="delay-test-stat">
+          <span class="delay-test-stat-label">{{ tt.fastest() }}</span>
+          <strong class="delay-test-value">{{ formatOffset(fastestOffsetMs) }}</strong>
+        </div>
+        <div class="delay-test-stat">
+          <span class="delay-test-stat-label">{{ tt.slowest() }}</span>
+          <strong class="delay-test-value">{{ formatOffset(slowestOffsetMs) }}</strong>
+        </div>
+      </div>
+
+      <div class="delay-test-chart">
+        <div class="delay-test-chart-center" />
+        <div
+          v-for="(sample, index) in chartSamples"
+          :key="`${index}-${sample}`"
+          class="delay-test-chart-sample"
+          :class="sample >= 0 ? 'fast' : 'slow'"
+          :style="sampleStyle(sample)"
+        />
+      </div>
+      <div class="delay-test-empty" v-if="chartSamples.length === 0">{{ tt.noSamples() }}</div>
+
+      <InputNumber
+        v-model="latencyBpm"
+        class="delay-test-bpm"
+        fluid
+        size="small"
+        :use-grouping="false"
+        :min="60"
+        :max="320"
+        :disabled="isRunning"
+      />
+      <div class="delay-test-bpm-label">{{ tt.bpmLabel() }}</div>
+
+      <div class="delay-test-actions">
+        <Button
+          :label="isRunning ? tt.stop() : tt.start()"
+          :icon="isRunning ? 'mdi mdi-stop' : 'mdi mdi-play'"
+          @click="handleToggleRunning"
+        />
+        <Button
+          :label="tt.applyCurrent()"
+          severity="secondary"
+          :disabled="currentOffsetMs === null || isRunning"
+          @click="handleApplyCurrent"
+        />
+        <Button
+          :label="tt.applyAverage()"
+          severity="secondary"
+          :disabled="averageOffsetMs === null || isRunning"
+          @click="handleApplyAverage"
+        />
+      </div>
+
+      <div class="delay-test-footer">{{ tt.signHint() }}</div>
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { t } from '@i18n'
+import { computed, onUnmounted, ref, shallowRef, watch } from 'vue'
+
+import type { HotKey } from '@core/hotkey'
+import { getHotkeyStr, isHotkeyMatch, matchHotkeyInMap, parseKeyEvent } from '@core/hotkey'
+import { usePrefStore } from '@states/stores'
+
+import { isInputEl } from '@utils/isInputEl'
+
+import { Button, Dialog, InputNumber } from 'primevue'
+
+const tt = t.delayTestDialog
+
+const [visible] = defineModel<boolean>({ required: true })
+
+const prefStore = usePrefStore()
+
+const isRunning = ref(false)
+const currentBeatIndex = ref(-1)
+const currentOffsetMs = ref<number | null>(null)
+const sampleOffsetsMs = ref<number[]>([])
+const chartRangeMs = computed(() => {
+  const maxAbs = Math.max(120, ...sampleOffsetsMs.value.map((v) => Math.abs(v)))
+  return Math.max(120, Math.ceil(maxAbs))
+})
+const chartSamples = computed(() => sampleOffsetsMs.value.slice(-100))
+const fastestOffsetMs = computed(() => {
+  if (chartSamples.value.length === 0) return null
+  return Math.max(...chartSamples.value)
+})
+const slowestOffsetMs = computed(() => {
+  if (chartSamples.value.length === 0) return null
+  return Math.min(...chartSamples.value)
+})
+const averageOffsetMs = computed(() => {
+  if (chartSamples.value.length === 0) return null
+  return Math.round(chartSamples.value.reduce((sum, value) => sum + value, 0) / chartSamples.value.length)
+})
+
+const latencyBpm = computed<number | null>({
+  get: () => prefStore.latencyTestBpm,
+  set: (value) => {
+    prefStore.latencyTestBpm = clampBpm(value ?? prefStore.latencyTestBpm)
+  },
+})
+const tapKeyLabel = computed(() => getHotkeyStr('delayTestTap') ?? t.hotkey.notBinded())
+
+const audioCtx = shallowRef<AudioContext | null>(null)
+let rafId = 0
+let sessionToken = 0
+let nextBeatTime = 0
+let nextBeatIndex = 0
+let beatIntervalSec = 0
+let startBeatTime = 0
+let sessionStartedAt = 0
+const tapPressState = ref<{ hotkey: HotKey.Key; downAt: number } | null>(null)
+
+function clampBpm(value: number) {
+  return Math.min(320, Math.max(60, Math.round(value)))
+}
+
+function formatOffset(value: number | null) {
+  if (value === null) return '—'
+  const sign = value > 0 ? '+' : value < 0 ? '-' : ''
+  return `${sign}${Math.abs(value)} ms`
+}
+
+function offsetTone(value: number | null) {
+  if (value === null) return 'neutral'
+  if (value > 0) return 'fast'
+  if (value < 0) return 'slow'
+  return 'neutral'
+}
+
+function sampleStyle(value: number) {
+  const range = chartRangeMs.value || 120
+  const normalized = Math.min(Math.abs(value) / range, 1)
+  return {
+    left: `${50 + (value / range) * 50}%`,
+    opacity: `${0.3 + normalized * 0.7}`,
+  }
+}
+
+async function ensureAudioContext() {
+  if (!audioCtx.value) audioCtx.value = new AudioContext({ latencyHint: 'interactive' })
+  return audioCtx.value
+}
+
+function clearFrame() {
+  if (rafId) cancelAnimationFrame(rafId)
+  rafId = 0
+}
+
+function resetSessionState() {
+  clearFrame()
+  sessionToken += 1
+  isRunning.value = false
+  currentBeatIndex.value = -1
+  currentOffsetMs.value = null
+  sampleOffsetsMs.value = []
+  tapPressState.value = null
+  nextBeatTime = 0
+  nextBeatIndex = 0
+  beatIntervalSec = 0
+  startBeatTime = 0
+  sessionStartedAt = 0
+}
+
+async function stopAudioContext() {
+  const ctx = audioCtx.value
+  audioCtx.value = null
+  if (!ctx) return
+  try {
+    await ctx.close()
+  } catch {
+    // ignore
+  }
+}
+
+async function stopSession(preserveResults: boolean = true) {
+  clearFrame()
+  sessionToken += 1
+  isRunning.value = false
+  currentBeatIndex.value = -1
+  tapPressState.value = null
+  if (!preserveResults) {
+    currentOffsetMs.value = null
+    sampleOffsetsMs.value = []
+  }
+  await stopAudioContext()
+}
+
+function scheduleBeep(ctx: AudioContext, beatTime: number, accent: boolean) {
+  const scheduleAt = Math.max(beatTime, ctx.currentTime + 0.005)
+  const osc = ctx.createOscillator()
+  const gain = ctx.createGain()
+  osc.type = 'sine'
+  osc.frequency.value = accent ? 880 : 660
+  gain.gain.setValueAtTime(0.0001, scheduleAt)
+  gain.gain.linearRampToValueAtTime(0.18, scheduleAt + 0.01)
+  gain.gain.exponentialRampToValueAtTime(0.0001, scheduleAt + 0.08)
+  osc.connect(gain)
+  gain.connect(ctx.destination)
+  osc.start(scheduleAt)
+  osc.stop(scheduleAt + 0.09)
+  osc.onended = () => {
+    osc.disconnect()
+    gain.disconnect()
+  }
+}
+
+function pushOffset(offsetMs: number) {
+  sampleOffsetsMs.value = [...sampleOffsetsMs.value, offsetMs].slice(-100)
+  currentOffsetMs.value = offsetMs
+}
+
+function recordHit(hitTime: number) {
+  if (!beatIntervalSec) return
+  const beatIndex = Math.max(0, Math.round((hitTime - startBeatTime) / beatIntervalSec))
+  const nearestBeatTime = startBeatTime + beatIndex * beatIntervalSec
+  pushOffset(Math.round((nearestBeatTime - hitTime) * 1000))
+}
+
+function frameLoop(ctx: AudioContext, token: number) {
+  if (token !== sessionToken || !isRunning.value) return
+
+  const now = ctx.currentTime
+  const intervalSec = beatIntervalSec
+  while (nextBeatTime - now < 0.3) {
+    scheduleBeep(ctx, nextBeatTime, nextBeatIndex === 0)
+    nextBeatTime += intervalSec
+    nextBeatIndex = (nextBeatIndex + 1) % 4
+  }
+
+  const elapsedMs = performance.now() - sessionStartedAt
+  if (elapsedMs >= 0) currentBeatIndex.value = Math.floor(elapsedMs / (intervalSec * 1000)) % 4
+  else currentBeatIndex.value = 0
+
+  rafId = requestAnimationFrame(() => frameLoop(ctx, token))
+}
+
+async function startSession() {
+  if (isRunning.value) return
+  const ctx = await ensureAudioContext()
+  const token = ++sessionToken
+  try {
+    await ctx.resume()
+  } catch {
+    return
+  }
+  if (token !== sessionToken) return
+
+  isRunning.value = true
+  currentOffsetMs.value = null
+  sampleOffsetsMs.value = []
+  tapPressState.value = null
+  currentBeatIndex.value = 0
+
+  const leadSec = 0.3
+  beatIntervalSec = 60 / clampBpm(prefStore.latencyTestBpm)
+  startBeatTime = ctx.currentTime + leadSec
+  sessionStartedAt = performance.now() + leadSec * 1000
+  nextBeatTime = startBeatTime + beatIntervalSec
+  nextBeatIndex = 1
+  scheduleBeep(ctx, startBeatTime, true)
+  rafId = requestAnimationFrame(() => frameLoop(ctx, token))
+}
+
+function handleToggleRunning() {
+  if (isRunning.value) void stopSession(true)
+  else void startSession()
+}
+
+function applyLatency(value: number | null) {
+  if (value === null) return
+  prefStore.globalLatencyMs = Math.min(5000, Math.max(-5000, Math.round(-value)))
+}
+
+function handleApplyCurrent() {
+  applyLatency(currentOffsetMs.value)
+}
+function handleApplyAverage() {
+  applyLatency(averageOffsetMs.value)
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (!visible.value || !isRunning.value) return
+  if (e.repeat) return
+  if (e.target instanceof HTMLElement && isInputEl(e.target)) return
+  const hotkey = parseKeyEvent(e)
+  if (!hotkey) return
+  if (matchHotkeyInMap(hotkey, prefStore.hotkeyMap) !== 'delayTestTap') return
+  e.preventDefault()
+  tapPressState.value = { hotkey, downAt: performance.now() }
+}
+
+function handleKeyup(e: KeyboardEvent) {
+  if (!visible.value || !isRunning.value) return
+  if (e.target instanceof HTMLElement && isInputEl(e.target)) return
+  const hotkey = parseKeyEvent(e)
+  if (!hotkey) return
+  if (matchHotkeyInMap(hotkey, prefStore.hotkeyMap) !== 'delayTestTap') return
+  e.preventDefault()
+  const tapState = tapPressState.value
+  if (!tapState || !isHotkeyMatch(tapState.hotkey, hotkey)) return
+  const ctx = audioCtx.value
+  if (!ctx) return
+  const upAt = performance.now()
+  const outputLatency = (ctx as AudioContext & { outputLatency?: number }).outputLatency ?? 0
+  const hitTime = ctx.currentTime + outputLatency - (upAt - tapState.downAt) / 2000
+  recordHit(hitTime)
+  tapPressState.value = null
+}
+
+watch(
+  visible,
+  (open) => {
+    if (open) {
+      resetSessionState()
+      window.addEventListener('keydown', handleKeydown, true)
+      window.addEventListener('keyup', handleKeyup, true)
+      return
+    }
+    window.removeEventListener('keydown', handleKeydown, true)
+    window.removeEventListener('keyup', handleKeyup, true)
+    void stopSession(false)
+    resetSessionState()
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown, true)
+  window.removeEventListener('keyup', handleKeyup, true)
+  void stopSession(false)
+})
+</script>
+
+<style lang="scss">
+.delay-test-dialog {
+  .delay-test-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-width: min(34rem, 90vw);
+  }
+
+  .delay-test-description,
+  .delay-test-footer,
+  .delay-test-empty,
+  .delay-test-stat-label {
+    opacity: 0.72;
+    font-size: 0.92rem;
+  }
+
+  .delay-test-hint {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .delay-test-key {
+    padding: 0.1rem 0.45rem;
+    border-radius: 0.35rem;
+    background: var(--p-surface-200);
+    font-family: var(--font-monospace);
+  }
+
+  .delay-test-beats {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin: 0.5rem 0 0.25rem;
+  }
+
+  .delay-test-beat {
+    width: 0.9rem;
+    height: 0.9rem;
+    border-radius: 999px;
+    background: var(--p-surface-300);
+    transition: transform 0.12s, background 0.12s, box-shadow 0.12s;
+
+    &.active {
+      background: var(--p-primary-color);
+      box-shadow: 0 0 0 0.35rem color-mix(in srgb, var(--p-primary-color) 20%, transparent);
+      transform: scale(1.1);
+    }
+  }
+
+  .delay-test-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .delay-test-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 0.5rem;
+    background: var(--p-surface-100);
+  }
+
+  .delay-test-value.fast {
+    color: var(--p-green-500);
+  }
+  .delay-test-value.slow {
+    color: var(--p-red-500);
+  }
+  .delay-test-value.neutral {
+    color: inherit;
+  }
+
+  .delay-test-chart {
+    position: relative;
+    height: 3rem;
+    border-radius: 0.5rem;
+    background: var(--p-surface-100);
+    overflow: hidden;
+  }
+
+  .delay-test-chart-center {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+    background: var(--p-primary-color);
+    opacity: 0.65;
+  }
+
+  .delay-test-chart-sample {
+    position: absolute;
+    top: 0.3rem;
+    bottom: 0.3rem;
+    width: 2px;
+    transform: translateX(-50%);
+    border-radius: 999px;
+
+    &.fast {
+      background: color-mix(in srgb, var(--p-green-500) 80%, white);
+    }
+
+    &.slow {
+      background: color-mix(in srgb, var(--p-red-500) 80%, white);
+    }
+  }
+
+  .delay-test-bpm {
+    --p-inputtext-padding-y: 0.4rem;
+    .p-inputtext.p-inputtext {
+      font-family: var(--font-monospace);
+      width: 0;
+    }
+  }
+
+  .delay-test-bpm-label {
+    margin-top: -0.25rem;
+    opacity: 0.7;
+    font-size: 0.92rem;
+  }
+
+  .delay-test-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/src/ui/dialogs/dialogComponents/DelayTestDialog.vue
+++ b/src/ui/dialogs/dialogComponents/DelayTestDialog.vue
@@ -92,7 +92,7 @@ import { t } from '@i18n'
 import { computed, onUnmounted, ref, shallowRef, watch } from 'vue'
 
 import type { HotKey } from '@core/hotkey'
-import { getHotkeyStr, isHotkeyMatch, matchHotkeyInMap, parseKeyEvent } from '@core/hotkey'
+import { getHotkeyStr, isHotkeyMatch, parseKeyEvent } from '@core/hotkey'
 import { usePrefStore } from '@states/stores'
 
 import { isInputEl } from '@utils/isInputEl'
@@ -144,6 +144,10 @@ let beatIntervalSec = 0
 let startBeatTime = 0
 let sessionStartedAt = 0
 const tapPressState = ref<{ hotkey: HotKey.Key; downAt: number } | null>(null)
+
+function isDelayTestTapHotkey(hotkey: HotKey.Key) {
+  return prefStore.hotkeyMap.delayTestTap.some((binding) => isHotkeyMatch(binding, hotkey))
+}
 
 function clampBpm(value: number) {
   return Math.min(320, Math.max(60, Math.round(value)))
@@ -319,7 +323,7 @@ function handleKeydown(e: KeyboardEvent) {
   if (e.target instanceof HTMLElement && isInputEl(e.target)) return
   const hotkey = parseKeyEvent(e)
   if (!hotkey) return
-  if (matchHotkeyInMap(hotkey, prefStore.hotkeyMap) !== 'delayTestTap') return
+  if (!isDelayTestTapHotkey(hotkey)) return
   e.preventDefault()
   tapPressState.value = { hotkey, downAt: performance.now() }
 }
@@ -329,7 +333,7 @@ function handleKeyup(e: KeyboardEvent) {
   if (e.target instanceof HTMLElement && isInputEl(e.target)) return
   const hotkey = parseKeyEvent(e)
   if (!hotkey) return
-  if (matchHotkeyInMap(hotkey, prefStore.hotkeyMap) !== 'delayTestTap') return
+  if (!isDelayTestTapHotkey(hotkey)) return
   e.preventDefault()
   const tapState = tapPressState.value
   if (!tapState || !isHotkeyMatch(tapState.hotkey, hotkey)) return

--- a/src/ui/dialogs/dialogComponents/DelayTestDialog.vue
+++ b/src/ui/dialogs/dialogComponents/DelayTestDialog.vue
@@ -368,6 +368,18 @@ onUnmounted(() => {
 
 <style lang="scss">
 .delay-test-dialog {
+  color: light-dark(var(--p-neutral-800), var(--p-neutral-100));
+  --delay-test-surface-soft: light-dark(var(--p-surface-50), var(--p-surface-900));
+  --delay-test-surface: light-dark(var(--p-surface-100), var(--p-surface-800));
+  --delay-test-surface-strong: light-dark(var(--p-surface-200), var(--p-surface-700));
+  --delay-test-border: light-dark(
+    color-mix(in srgb, var(--p-surface-300), transparent 20%),
+    color-mix(in srgb, var(--p-surface-600), transparent 35%)
+  );
+  --delay-test-text-muted: light-dark(var(--p-neutral-700), var(--p-neutral-200));
+  --delay-test-text-fast: light-dark(var(--p-green-700), var(--p-green-300));
+  --delay-test-text-slow: light-dark(var(--p-red-700), var(--p-red-300));
+
   .delay-test-content {
     display: flex;
     flex-direction: column;
@@ -379,7 +391,7 @@ onUnmounted(() => {
   .delay-test-footer,
   .delay-test-empty,
   .delay-test-stat-label {
-    opacity: 0.72;
+    color: var(--delay-test-text-muted);
     font-size: 0.92rem;
   }
 
@@ -392,7 +404,8 @@ onUnmounted(() => {
   .delay-test-key {
     padding: 0.1rem 0.45rem;
     border-radius: 0.35rem;
-    background: var(--p-surface-200);
+    background: var(--delay-test-surface-strong);
+    border: 1px solid var(--delay-test-border);
     font-family: var(--font-monospace);
   }
 
@@ -407,11 +420,12 @@ onUnmounted(() => {
     width: 0.9rem;
     height: 0.9rem;
     border-radius: 999px;
-    background: var(--p-surface-300);
+    background: var(--delay-test-surface-strong);
+    border: 1px solid var(--delay-test-border);
     transition: transform 0.12s, background 0.12s, box-shadow 0.12s;
 
     &.active {
-      background: var(--p-primary-color);
+      background: light-dark(var(--p-primary-500), var(--p-primary-400));
       box-shadow: 0 0 0 0.35rem color-mix(in srgb, var(--p-primary-color) 20%, transparent);
       transform: scale(1.1);
     }
@@ -429,24 +443,28 @@ onUnmounted(() => {
     gap: 0.15rem;
     padding: 0.6rem 0.75rem;
     border-radius: 0.5rem;
-    background: var(--p-surface-100);
+    background: var(--delay-test-surface);
+    border: 1px solid var(--delay-test-border);
+    box-shadow: inset 0 1px 0
+      light-dark(color-mix(in srgb, white 55%, transparent), color-mix(in srgb, black 35%, transparent));
   }
 
   .delay-test-value.fast {
-    color: var(--p-green-500);
+    color: var(--delay-test-text-fast);
   }
   .delay-test-value.slow {
-    color: var(--p-red-500);
+    color: var(--delay-test-text-slow);
   }
   .delay-test-value.neutral {
-    color: inherit;
+    color: var(--delay-test-text-muted);
   }
 
   .delay-test-chart {
     position: relative;
     height: 3rem;
     border-radius: 0.5rem;
-    background: var(--p-surface-100);
+    background: var(--delay-test-surface-soft);
+    border: 1px solid var(--delay-test-border);
     overflow: hidden;
   }
 
@@ -457,7 +475,7 @@ onUnmounted(() => {
     left: 50%;
     width: 2px;
     transform: translateX(-50%);
-    background: var(--p-primary-color);
+    background: light-dark(var(--p-primary-500), var(--p-primary-400));
     opacity: 0.65;
   }
 
@@ -470,11 +488,17 @@ onUnmounted(() => {
     border-radius: 999px;
 
     &.fast {
-      background: color-mix(in srgb, var(--p-green-500) 80%, white);
+      background: light-dark(
+        color-mix(in srgb, var(--p-green-600) 85%, white),
+        color-mix(in srgb, var(--p-green-300) 85%, black)
+      );
     }
 
     &.slow {
-      background: color-mix(in srgb, var(--p-red-500) 80%, white);
+      background: light-dark(
+        color-mix(in srgb, var(--p-red-600) 85%, white),
+        color-mix(in srgb, var(--p-red-300) 85%, black)
+      );
     }
   }
 
@@ -488,7 +512,7 @@ onUnmounted(() => {
 
   .delay-test-bpm-label {
     margin-top: -0.25rem;
-    opacity: 0.7;
+    color: var(--delay-test-text-muted);
     font-size: 0.92rem;
   }
 

--- a/src/ui/dialogs/dialogComponents/KeyBindingDialog.vue
+++ b/src/ui/dialogs/dialogComponents/KeyBindingDialog.vue
@@ -109,6 +109,7 @@ const groupedCmdList = [
       'playPauseAudio',
       'seekForward',
       'volumeDown',
+      'delayTestTap',
     ],
   },
 ] as const satisfies {

--- a/src/ui/dialogs/index.ts
+++ b/src/ui/dialogs/index.ts
@@ -3,6 +3,7 @@ import type { Component } from 'vue'
 import type { ValueOf } from '@utils/types'
 
 import AboutDialog from './dialogComponents/AboutDialog.vue'
+import DelayTestDialog from './dialogComponents/DelayTestDialog.vue'
 import BatchTimeShiftDialog from './dialogComponents/BatchTimeShiftDialog.vue'
 import CompatibilityDialog from './dialogComponents/CompatibilityDialog.vue'
 import FindReplaceDialog from './dialogComponents/FindReplaceDialog.vue'
@@ -11,6 +12,7 @@ import FromTextModal from './dialogComponents/FromTextModal.vue'
 import KeyBindingDialog from './dialogComponents/KeyBindingDialog.vue'
 
 export const DialogKey = {
+  DelayTest: 'delayTest',
   BatchTimeShift: 'batchTimeShift',
   FindReplace: 'findReplace',
   KeyBinding: 'keyBinding',
@@ -27,6 +29,7 @@ interface DialogReg {
 }
 
 export const dialogRegs: DialogReg[] = [
+  { key: DialogKey.DelayTest, component: DelayTestDialog },
   { key: DialogKey.BatchTimeShift, component: BatchTimeShiftDialog },
   { key: DialogKey.FindReplace, component: FindReplaceDialog },
   { key: DialogKey.KeyBinding, component: KeyBindingDialog },

--- a/src/ui/ribbon/groups/TimeShiftGroup.vue
+++ b/src/ui/ribbon/groups/TimeShiftGroup.vue
@@ -4,8 +4,9 @@
       icon="mdi mdi-timer-music-outline"
       :label="tt.delayTest()"
       size="small"
-      severity="secondary"
-      disabled
+      :severity="runtimeStore.dialogShown.delayTest ? undefined : 'secondary'"
+      @click="runtimeStore.dialogShown.delayTest = !runtimeStore.dialogShown.delayTest"
+      v-tooltip="tipDesc(tt.delayTest(), tt.delayTestDesc(), 'delayTestTap')"
     />
     <div class="hflex" style="align-items: center; gap: 0.5rem">
       <span>{{ tt.delay() }}</span>


### PR DESCRIPTION
添加一个新的延迟测试对话框，通过在可配置的 BPM 鸣响时点击来测量输入延迟。包括热键绑定、偏好设置以及在时间偏移组中的 UI 集成。支持应用当前或平均延迟值。